### PR TITLE
Fix bug in get_coords

### DIFF
--- a/mmtf/api/mmtf_reader.py
+++ b/mmtf/api/mmtf_reader.py
@@ -15,7 +15,7 @@ class MMTFDecoder(object):
         """Utility function to get the coordinates as a single list of tuples."""
         out_list = []
         for i in range(len(self.x_coord_list)):
-            out_list.append((self.x_coord_list[i],self.y_coord_list[i],self.z_coord_list,))
+            out_list.append((self.x_coord_list[i],self.y_coord_list[i],self.z_coord_list[i],))
         return out_list
 
     def get_bonds(self):


### PR DESCRIPTION
get_coords() currently returns a list of coordinate tuples where the third position of each tuple is the entire list of z positions rather than the corresponding z position. For example:

```python
In [70]: pdb_2dog.get_coords()[0]
Out[70]: 
(-16.847000000000001,
 2.899,
 array([ 8.705,  7.462,  7.05 , ..., -7.325, -8.086, -7.866]))
```